### PR TITLE
docs(roadmaps): replace mentorship CTAs with CertGames

### DIFF
--- a/ROADMAPS/APPLICATION-SECURITY.md
+++ b/ROADMAPS/APPLICATION-SECURITY.md
@@ -8,7 +8,7 @@ Application Security professionals work with development teams to build secure s
 
 ---
 
-> **Want 1-on-1 guidance through this path?** I offer a mentorship program where I personally help you get certified, build real projects for your GitHub, rewrite your resume, and land your first cybersecurity role. **[Learn more](https://certgames.com/mentorship)**
+> **Studying for the certifications below?** Practice with [CertGames](https://certgames.com) — 18,000+ practice questions across 18 certifications (CompTIA, AWS, Cisco, ISC2), 5 security training games, and 11 AI learning tools. Free to start, no credit card required. **[Start practicing free](https://certgames.com)**
 
 ---
 
@@ -317,7 +317,7 @@ Build application security skills with these projects:
 
 ---
 
-> **This is a lot to tackle alone.** If you want someone guiding you through the certifications, building your projects, and getting your resume right — my 1-on-1 mentorship covers the full process for 90 days. **[certgames.com/mentorship](https://certgames.com/mentorship)**
+> **The certification grind is rough.** Make it less painful with [CertGames](https://certgames.com) — gamified practice tests where you earn XP, level up, build streaks, and compete on leaderboards. 18,000+ questions across 18 certs. Free to start. **[certgames.com](https://certgames.com)**
 
 ---
 

--- a/ROADMAPS/CLOUD-SECURITY-ENGINEER.md
+++ b/ROADMAPS/CLOUD-SECURITY-ENGINEER.md
@@ -8,7 +8,7 @@ Cloud Security Engineers design, implement, and maintain security controls for c
 
 ---
 
-> **Want 1-on-1 guidance through this path?** I offer a mentorship program where I personally help you get certified, build real projects for your GitHub, rewrite your resume, and land your first cybersecurity role. **[Learn more](https://certgames.com/mentorship)**
+> **Studying for the certifications below?** Practice with [CertGames](https://certgames.com) — 18,000+ practice questions across 18 certifications (CompTIA, AWS, Cisco, ISC2), 5 security training games, and 11 AI learning tools. Free to start, no credit card required. **[Start practicing free](https://certgames.com)**
 
 ---
 
@@ -245,7 +245,7 @@ Build cloud security skills with these projects:
 
 ---
 
-> **This is a lot to tackle alone.** If you want someone guiding you through the certifications, building your projects, and getting your resume right — my 1-on-1 mentorship covers the full process for 90 days. **[certgames.com/mentorship](https://certgames.com/mentorship)**
+> **The certification grind is rough.** Make it less painful with [CertGames](https://certgames.com) — gamified practice tests where you earn XP, level up, build streaks, and compete on leaderboards. 18,000+ questions across 18 certs. Free to start. **[certgames.com](https://certgames.com)**
 
 ---
 

--- a/ROADMAPS/GRC-ANALYST.md
+++ b/ROADMAPS/GRC-ANALYST.md
@@ -8,7 +8,7 @@ GRC Analysts ensure organizations meet security standards and regulatory require
 
 ---
 
-> **Want 1-on-1 guidance through this path?** I offer a mentorship program where I personally help you get certified, build real projects for your GitHub, rewrite your resume, and land your first cybersecurity role. **[Learn more](https://certgames.com/mentorship)**
+> **Studying for the certifications below?** Practice with [CertGames](https://certgames.com) — 18,000+ practice questions across 18 certifications (CompTIA, AWS, Cisco, ISC2), 5 security training games, and 11 AI learning tools. Free to start, no credit card required. **[Start practicing free](https://certgames.com)**
 
 ---
 
@@ -262,7 +262,7 @@ Understand GRC through practical application:
 
 ---
 
-> **This is a lot to tackle alone.** If you want someone guiding you through the certifications, building your projects, and getting your resume right — my 1-on-1 mentorship covers the full process for 90 days. **[certgames.com/mentorship](https://certgames.com/mentorship)**
+> **The certification grind is rough.** Make it less painful with [CertGames](https://certgames.com) — gamified practice tests where you earn XP, level up, build streaks, and compete on leaderboards. 18,000+ questions across 18 certs. Free to start. **[certgames.com](https://certgames.com)**
 
 ---
 

--- a/ROADMAPS/INCIDENT-RESPONDER.md
+++ b/ROADMAPS/INCIDENT-RESPONDER.md
@@ -8,7 +8,7 @@ Incident Responders are the front-line defenders when security incidents occur. 
 
 ---
 
-> **Want 1-on-1 guidance through this path?** I offer a mentorship program where I personally help you get certified, build real projects for your GitHub, rewrite your resume, and land your first cybersecurity role. **[Learn more](https://certgames.com/mentorship)**
+> **Studying for the certifications below?** Practice with [CertGames](https://certgames.com) — 18,000+ practice questions across 18 certifications (CompTIA, AWS, Cisco, ISC2), 5 security training games, and 11 AI learning tools. Free to start, no credit card required. **[Start practicing free](https://certgames.com)**
 
 ---
 
@@ -204,7 +204,7 @@ Practice incident response skills with these projects:
 
 ---
 
-> **This is a lot to tackle alone.** If you want someone guiding you through the certifications, building your projects, and getting your resume right — my 1-on-1 mentorship covers the full process for 90 days. **[certgames.com/mentorship](https://certgames.com/mentorship)**
+> **The certification grind is rough.** Make it less painful with [CertGames](https://certgames.com) — gamified practice tests where you earn XP, level up, build streaks, and compete on leaderboards. 18,000+ questions across 18 certs. Free to start. **[certgames.com](https://certgames.com)**
 
 ---
 

--- a/ROADMAPS/NETWORK-ENGINEER.md
+++ b/ROADMAPS/NETWORK-ENGINEER.md
@@ -8,7 +8,7 @@ Network Engineers with security focus build and maintain secure network infrastr
 
 ---
 
-> **Want 1-on-1 guidance through this path?** I offer a mentorship program where I personally help you get certified, build real projects for your GitHub, rewrite your resume, and land your first cybersecurity role. **[Learn more](https://certgames.com/mentorship)**
+> **Studying for the certifications below?** Practice with [CertGames](https://certgames.com) — 18,000+ practice questions across 18 certifications (CompTIA, AWS, Cisco, ISC2), 5 security training games, and 11 AI learning tools. Free to start, no credit card required. **[Start practicing free](https://certgames.com)**
 
 ---
 
@@ -292,7 +292,7 @@ Build network security skills with these projects:
 
 ---
 
-> **This is a lot to tackle alone.** If you want someone guiding you through the certifications, building your projects, and getting your resume right — my 1-on-1 mentorship covers the full process for 90 days. **[certgames.com/mentorship](https://certgames.com/mentorship)**
+> **The certification grind is rough.** Make it less painful with [CertGames](https://certgames.com) — gamified practice tests where you earn XP, level up, build streaks, and compete on leaderboards. 18,000+ questions across 18 certs. Free to start. **[certgames.com](https://certgames.com)**
 
 ---
 

--- a/ROADMAPS/PENTESTER.md
+++ b/ROADMAPS/PENTESTER.md
@@ -8,7 +8,7 @@ Penetration testers ethically hack systems to identify vulnerabilities before ma
 
 ---
 
-> **Want 1-on-1 guidance through this path?** I offer a mentorship program where I personally help you get certified, build real projects for your GitHub, rewrite your resume, and land your first cybersecurity role. **[Learn more](https://certgames.com/mentorship)**
+> **Studying for the certifications below?** Practice with [CertGames](https://certgames.com) — 18,000+ practice questions across 18 certifications (CompTIA, AWS, Cisco, ISC2), 5 security training games, and 11 AI learning tools. Free to start, no credit card required. **[Start practicing free](https://certgames.com)**
 
 ---
 
@@ -174,7 +174,7 @@ Build pentesting skills with these projects:
 
 ---
 
-> **This is a lot to tackle alone.** If you want someone guiding you through the certifications, building your projects, and getting your resume right — my 1-on-1 mentorship covers the full process for 90 days. **[certgames.com/mentorship](https://certgames.com/mentorship)**
+> **The certification grind is rough.** Make it less painful with [CertGames](https://certgames.com) — gamified practice tests where you earn XP, level up, build streaks, and compete on leaderboards. 18,000+ questions across 18 certs. Free to start. **[certgames.com](https://certgames.com)**
 
 ---
 

--- a/ROADMAPS/README.md
+++ b/ROADMAPS/README.md
@@ -66,7 +66,7 @@ Structured certification paths for different cybersecurity career tracks. Each r
 
 ---
 
-> **Want 1-on-1 guidance?** I offer a mentorship program where I personally help you get certified, build real projects for your GitHub, rewrite your resume, and land your first cybersecurity role. **[Learn more](https://certgames.com/mentorship)**
+> **Studying for the certifications below?** Practice with [CertGames](https://certgames.com) — 18,000+ practice questions across 18 certifications (CompTIA, AWS, Cisco, ISC2), 5 security training games, and 11 AI learning tools. Free to start, no credit card required. **[Start practicing free](https://certgames.com)**
 
 ---
 
@@ -132,7 +132,7 @@ Structured certification paths for different cybersecurity career tracks. Each r
 
 ---
 
-> **This is a lot to tackle alone.** If you want someone guiding you through the certifications, building your projects, and getting your resume right — my 1-on-1 mentorship covers the full process for 90 days. **[certgames.com/mentorship](https://certgames.com/mentorship)**
+> **The certification grind is rough.** Make it less painful with [CertGames](https://certgames.com) — gamified practice tests where you earn XP, level up, build streaks, and compete on leaderboards. 18,000+ questions across 18 certs. Free to start. **[certgames.com](https://certgames.com)**
 
 ---
 

--- a/ROADMAPS/SECURITY-ARCHITECT.md
+++ b/ROADMAPS/SECURITY-ARCHITECT.md
@@ -8,7 +8,7 @@ Security Architects design the overall security infrastructure for organizations
 
 ---
 
-> **Want 1-on-1 guidance through this path?** I offer a mentorship program where I personally help you get certified, build real projects for your GitHub, rewrite your resume, and land your first cybersecurity role. **[Learn more](https://certgames.com/mentorship)**
+> **Studying for the certifications below?** Practice with [CertGames](https://certgames.com) — 18,000+ practice questions across 18 certifications (CompTIA, AWS, Cisco, ISC2), 5 security training games, and 11 AI learning tools. Free to start, no credit card required. **[Start practicing free](https://certgames.com)**
 
 ---
 
@@ -235,7 +235,7 @@ Understand architecture through implementation:
 
 ---
 
-> **This is a lot to tackle alone.** If you want someone guiding you through the certifications, building your projects, and getting your resume right — my 1-on-1 mentorship covers the full process for 90 days. **[certgames.com/mentorship](https://certgames.com/mentorship)**
+> **The certification grind is rough.** Make it less painful with [CertGames](https://certgames.com) — gamified practice tests where you earn XP, level up, build streaks, and compete on leaderboards. 18,000+ questions across 18 certs. Free to start. **[certgames.com](https://certgames.com)**
 
 ---
 

--- a/ROADMAPS/SECURITY-ENGINEER.md
+++ b/ROADMAPS/SECURITY-ENGINEER.md
@@ -8,7 +8,7 @@ Security Engineers build and maintain the technical security infrastructure that
 
 ---
 
-> **Want 1-on-1 guidance through this path?** I offer a mentorship program where I personally help you get certified, build real projects for your GitHub, rewrite your resume, and land your first cybersecurity role. **[Learn more](https://certgames.com/mentorship)**
+> **Studying for the certifications below?** Practice with [CertGames](https://certgames.com) — 18,000+ practice questions across 18 certifications (CompTIA, AWS, Cisco, ISC2), 5 security training games, and 11 AI learning tools. Free to start, no credit card required. **[Start practicing free](https://certgames.com)**
 
 ---
 
@@ -180,7 +180,7 @@ Build security engineering skills with these projects:
 
 ---
 
-> **This is a lot to tackle alone.** If you want someone guiding you through the certifications, building your projects, and getting your resume right — my 1-on-1 mentorship covers the full process for 90 days. **[certgames.com/mentorship](https://certgames.com/mentorship)**
+> **The certification grind is rough.** Make it less painful with [CertGames](https://certgames.com) — gamified practice tests where you earn XP, level up, build streaks, and compete on leaderboards. 18,000+ questions across 18 certs. Free to start. **[certgames.com](https://certgames.com)**
 
 ---
 

--- a/ROADMAPS/SOC-ANALYST.md
+++ b/ROADMAPS/SOC-ANALYST.md
@@ -8,7 +8,7 @@ SOC Analysts monitor, detect, investigate, and respond to cybersecurity threats.
 
 ---
 
-> **Want 1-on-1 guidance through this path?** I offer a mentorship program where I personally help you get certified, build real projects for your GitHub, rewrite your resume, and land your first cybersecurity role. **[Learn more](https://certgames.com/mentorship)**
+> **Studying for the certifications below?** Practice with [CertGames](https://certgames.com) — 18,000+ practice questions across 18 certifications (CompTIA, AWS, Cisco, ISC2), 5 security training games, and 11 AI learning tools. Free to start, no credit card required. **[Start practicing free](https://certgames.com)**
 
 ---
 
@@ -143,7 +143,7 @@ Practice SOC skills with these projects:
 
 ---
 
-> **This is a lot to tackle alone.** If you want someone guiding you through the certifications, building your projects, and getting your resume right — my 1-on-1 mentorship covers the full process for 90 days. **[certgames.com/mentorship](https://certgames.com/mentorship)**
+> **The certification grind is rough.** Make it less painful with [CertGames](https://certgames.com) — gamified practice tests where you earn XP, level up, build streaks, and compete on leaderboards. 18,000+ questions across 18 certs. Free to start. **[certgames.com](https://certgames.com)**
 
 ---
 

--- a/ROADMAPS/THREAT-INTELLIGENCE-ANALYST.md
+++ b/ROADMAPS/THREAT-INTELLIGENCE-ANALYST.md
@@ -8,7 +8,7 @@ Threat Intelligence Analysts research adversaries, analyze attack patterns, and 
 
 ---
 
-> **Want 1-on-1 guidance through this path?** I offer a mentorship program where I personally help you get certified, build real projects for your GitHub, rewrite your resume, and land your first cybersecurity role. **[Learn more](https://certgames.com/mentorship)**
+> **Studying for the certifications below?** Practice with [CertGames](https://certgames.com) — 18,000+ practice questions across 18 certifications (CompTIA, AWS, Cisco, ISC2), 5 security training games, and 11 AI learning tools. Free to start, no credit card required. **[Start practicing free](https://certgames.com)**
 
 ---
 
@@ -263,7 +263,7 @@ Build threat intelligence skills with these projects:
 
 ---
 
-> **This is a lot to tackle alone.** If you want someone guiding you through the certifications, building your projects, and getting your resume right — my 1-on-1 mentorship covers the full process for 90 days. **[certgames.com/mentorship](https://certgames.com/mentorship)**
+> **The certification grind is rough.** Make it less painful with [CertGames](https://certgames.com) — gamified practice tests where you earn XP, level up, build streaks, and compete on leaderboards. 18,000+ questions across 18 certs. Free to start. **[certgames.com](https://certgames.com)**
 
 ---
 


### PR DESCRIPTION
Mentorship program is no longer offered. Swap top and bottom CTAs across all 11 roadmaps (10 paths + README) to point to certgames.com — practice tests / training games / AI tools.

## Description

Provide a clear description of what this pull request does.

## Type of Change

- [ ] New project idea (SYNOPSES)
- [ ] Full project implementation
- [ ] Bug fix
- [x] Documentation improvement
- [ ] Other (please describe)

## Checklist

**General:**
- [ ] My code follows the existing style and conventions
- [ ] I have tested my changes
- [ ] I have updated relevant documentation
- [ ] My changes do not introduce security vulnerabilities
- [ ] I have read the CONTRIBUTING.md guidelines

## Related Issues

Link any related issues here (e.g., "Fixes #123").

## Additional Context

Any other information that reviewers should know.
