### PR TITLE
Fix Docker configurations, nginx routing, and TypeScript deprecations

### DIFF
--- a/PROJECTS/intermediate/api-security-scanner/frontend/tsconfig.app.json
+++ b/PROJECTS/intermediate/api-security-scanner/frontend/tsconfig.app.json
@@ -13,7 +13,6 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "isolatedModules": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
Changes Made to API Security Scanner Project
Docker Configuration Updates
Python Version Upgrade
The project required Python 3.13+ according to the backend's [pyproject.toml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), but the Dockerfiles were using Python 3.11. Both production and development FastAPI Dockerfiles were updated to use FROM python:3.13-slim instead of python:3.11-slim. This ensures the backend dependencies can be properly installed without version conflicts.

Dependency Installation Method
The original Dockerfiles were attempting to copy a backend/requirements.txt file that didn't exist. The project uses modern Python packaging with [pyproject.toml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). Both Dockerfiles were updated to:

Copy backend/pyproject.toml instead of requirements.txt
Install dependencies using pip install --no-cache-dir . instead of pip install -r requirements.txt
Frontend Package Manager Update
The frontend uses pnpm as the package manager with a pnpm-lock.yaml lockfile, but both production and development Vite Dockerfiles were configured for npm. The Dockerfiles were updated to:

Install pnpm globally in the container
Copy both [package.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and pnpm-lock.yaml
Use pnpm install --frozen-lockfile for dependency installation
Update the build and dev commands to use pnpm instead of npm
Frontend Configuration Updates
TypeScript Configuration
The tsconfig.app.json file contained the deprecated baseUrl option which will stop functioning in TypeScript 7.0. Since the project already uses path aliases (@/* pointing to ./src/*), the baseUrl was removed as it's no longer needed for module resolution.

Package Dependencies
The frontend build was failing because TypeScript couldn't find the process object definition. The @types/node package was added to the devDependencies in [package.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to provide TypeScript definitions for Node.js globals used in configuration files.

API Configuration
The frontend API URL configuration in src/config/constants.ts was updated to use [/api/](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with a trailing slash instead of [/api](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). This matches the nginx routing configuration and ensures proper path handling when the API base URL is stripped of the path prefix.

Nginx Routing Configuration
Location Prefix Fix
The production nginx configuration was updated from [location /api](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [location /api/](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with a trailing slash. This is critical because:

nginx treats [location /api](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) differently from [location /api/](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Without the trailing slash, requests to [/api/auth/register](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) would be sent to the backend as [//auth/register](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (double slash)
With the trailing slash, the [/api](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) prefix is properly stripped when proxying to http://backend/
Environment Configuration
Environment Files
The [.env](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [.env.example](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) files were updated with the corrected [VITE_API_URL](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) value:

Changed from http://localhost/api to http://localhost/api/ (added trailing slash)
Updated comments to reflect the correct endpoints for both Docker nginx setup and local Vite development