### PR TITLE
ci(lint): install nph from git HEAD to dodge nimble SAT solver

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -232,7 +232,7 @@ jobs:
 
     - name: Install nph
       if: matrix.type == 'nim'
-      run: nimble install -y nph
+      run: nimble install -y "https://github.com/arnetheduck/nph"
 
     # Rust Setup (pinned to match locally-verified clippy version)
     - name: Install Rust 1.92.0


### PR DESCRIPTION
## Summary
- Post-merge of #256, the `credential-enumeration` lint job started failing on main even though the same workflow passed on the PR.
- Root cause is nimble's SAT solver, not our code: tagged nph releases either pin `nim < 2.1` or carry broken transitive deps (`toml_serialization`, `hldiff`), while `choosenim` installs Nim 2.2.10. The PR run happened to resolve nph from HEAD and built fine; the main-branch run hit a different resolution path and failed.
- Install nph directly from `https://github.com/arnetheduck/nph` so nimble fetches HEAD instead of solving across tagged versions.

## Test plan
- [x] `Lint credential-enumeration` job goes green on this PR
- [x] After merge, `Lint & Type Check` on main runs all 45 jobs green