### PR TITLE
Add Kerberos TGS-REP and AS-REP prefix detection

### DIFF
--- a/PROJECTS/foundations/hash-identifier/hash_identifier.py
+++ b/PROJECTS/foundations/hash-identifier/hash_identifier.py
@@ -177,8 +177,24 @@ PREFIX_RULES: list[tuple[str, str, str]] = [
     ("{SHA}", "LDAP SHA", "LDAP SHA-1 (base64 payload)"),
     ("{SMD5}", "LDAP SMD5", "LDAP salted MD5 (base64 payload)"),
     ("{MD5}", "LDAP MD5", "LDAP MD5 (base64 payload)"),
+
     ("{CRYPT}", "LDAP CRYPT", "LDAP wrapping a crypt(3) hash"),
+
+    # Kerberos — Active Directory attack hashes. Both are emitted by
+    # Impacket's GetUserSPNs.py / GetNPUsers.py and Rubeus in
+    # "hashcat" format. The digit right after the second `$` is the
+    # Kerberos encryption type (23 = RC4, 17 = AES128, 18 = AES256)
+    # and decides which hashcat -m mode to crack it with, but it does
+    # not change WHAT the hash is, so we match on the prefix alone
+    ("$krb5tgs$", "Kerberos TGS-REP (Kerberoasting)",
+     "service ticket hash from Kerberoasting; etype digit after $krb5tgs$ "
+     "(23=RC4, 17/18=AES) picks the hashcat mode"),
+    ("$krb5asrep$", "Kerberos AS-REP (AS-REP Roasting)",
+     "pre-auth-disabled account hash from AS-REP roasting; etype digit "
+     "after $krb5asrep$ (23=RC4, 17/18=AES) picks the hashcat mode"),
+
 ]
+
 
 
 # =============================================================================

--- a/PROJECTS/foundations/hash-identifier/test_hash_identifier.py
+++ b/PROJECTS/foundations/hash-identifier/test_hash_identifier.py
@@ -141,6 +141,41 @@ def test_django_pbkdf2_prefix_is_recognized() -> None:
     assert candidates[0].algorithm == "Django PBKDF2-SHA256"
 
 
+def test_kerberos_tgs_prefix_is_recognized() -> None:
+    """
+    Kerberoasting hashes start with `$krb5tgs$` and should be
+    reported as a Kerberos TGS-REP with HIGH confidence
+
+    Sample is a real-shaped RC4 (`etype 23`) service ticket hash,
+    the format Impacket's GetUserSPNs.py and Rubeus both emit.
+    identify() never decodes the ticket payload, so a short
+    fake tail after the two known `$`-delimited fields is enough
+    """
+    # $krb5tgs$<etype>$*<user>$<realm>$<spn>*$<checksum>$<edata2>
+    sample = "$krb5tgs$23$*user$REALM.COM$cifs/host.realm.com*$checksumhere$edata2here"
+    candidates = identify(sample)
+    assert candidates
+    assert candidates[0].algorithm == "Kerberos TGS-REP (Kerberoasting)"
+    assert candidates[0].confidence == "high"
+
+
+def test_kerberos_asrep_prefix_is_recognized() -> None:
+    """
+    AS-REP roasting hashes start with `$krb5asrep$` and should be
+    reported as a Kerberos AS-REP with HIGH confidence
+
+    Sample mirrors what Impacket's GetNPUsers.py and Rubeus's
+    `asreproast` output for an account with Kerberos pre-auth
+    disabled. As with TGS-REP, identify() only inspects the prefix
+    """
+    # $krb5asrep$<etype>$<user>@<realm>:<checksum>$<edata2>
+    sample = "$krb5asrep$23$user@REALM.COM:checksumhere$edata2here"
+    candidates = identify(sample)
+    assert candidates
+    assert candidates[0].algorithm == "Kerberos AS-REP (AS-REP Roasting)"
+    assert candidates[0].confidence == "high"
+
+
 def test_apr1_prefix_is_recognized() -> None:
     """
     Apache `.htpasswd` MD5 hashes start with $apr1$


### PR DESCRIPTION
## What

Adds detection for two Kerberos hash formats to `PREFIX_RULES`:

- `$krb5tgs$` — Kerberos TGS-REP (Kerberoasting)
- `$krb5asrep$` — Kerberos AS-REP (AS-REP Roasting)

## Why

Both formats are extremely common in real-world Active Directory
penetration testing but weren't covered by the existing prefix
table. They're the standard "hashcat format" output produced by:

- Impacket's `GetUserSPNs.py` (Kerberoasting → `$krb5tgs$`)
- Impacket's `GetNPUsers.py` (AS-REP roasting → `$krb5asrep$`)
- Rubeus (`kerberoast` / `asreproast` modes)

Cracking a `$krb5tgs$` hash recovers a **service account's**
password; cracking a `$krb5asrep$` hash recovers a **user
account's** password (from accounts with Kerberos pre-auth
disabled). Both are offline attacks, and identifying which one
you're looking at is the first step before picking a hashcat mode.

The reason string also calls out that the digit right after the
second `$` is the Kerberos encryption type (23 = RC4, 17 = AES128,
18 = AES256), which determines the exact hashcat `-m` mode
(e.g. 13100 vs 19600/19700 for TGS-REP, 18200 for AS-REP) — useful
context for anyone using this tool as the first step before cracking.

## Testing

- Added `test_kerberos_tgs_prefix_is_recognized` and
  `test_kerberos_asrep_prefix_is_recognized`, following the existing
  test file's style (docstring explaining the scenario + sample hash
  shape + assertion on algorithm/confidence).
- Both new rules are automatically covered by the existing
  `test_every_prefix_rule_is_recognized_with_high_confidence`
  parametrized test, so no separate table needs to stay in sync.
- `just test` → 50 passed
- `just lint` → ruff clean, pylint 10.00/10, mypy clean
- `just format` applied for consistent style

## Sample hashes used in tests

Shaped to match real Impacket/Rubeus output structure (not decoded —
`identify()` only inspects the prefix, so the tail is a placeholder):

```
$krb5tgs$23$*user$REALM.COM$cifs/host.realm.com*$checksum$edata2
$krb5asrep$23$user@REALM.COM:checksum$edata2
```